### PR TITLE
Fix: Simplify CSP meta tag in index.html and provide recommendations

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TravelStoreHN</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; connect-src 'self';">
   <script type="module" crossorigin src="./assets/index.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-800">


### PR DESCRIPTION
I modified the Content-Security-Policy meta tag in `index.html` by removing the `script-src` and `style-src` directives. The original meta tag was:
`default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self';` The new meta tag is:
`default-src 'self'; img-src 'self' data: https:; connect-src 'self';`

This change is speculative and aims to simplify the CSP configuration, making the HTTP header CSP the sole authority for script and style loading. The primary issue I identified is that an HTTP header `Content-Security-Policy` is being enforced with the `'strict-dynamic'` directive, which blocks the loading of `assets/index.js`.

**Recommendations for you:**

The root cause of the script loading failure (and consequently, styling issues) is likely the `Content-Security-Policy` HTTP header enforced by your hosting platform (e.g., GitHub Pages, Cloudflare). To resolve this, you will need to modify this HTTP header. Here are the recommended approaches:

1.  **Using a Nonce (Recommended if you can dynamically alter `index.html` or HTTP headers per request):**
    *   Modify your server/hosting configuration to add a unique, randomly generated nonce value to the `script-src` directive in the `Content-Security-Policy` HTTP header. Example: `script-src 'strict-dynamic' 'nonce-RANDOM_VALUE_HERE' 'unsafe-eval';`
    *   Add this same nonce to the script tag in your `index.html`: `<script type="module" crossorigin src="./assets/index.js" nonce="RANDOM_VALUE_HERE"></script>`.
    *   The nonce must be unique for each request.

2.  **Using a Hash (Suitable for static content if `assets/index.js` doesn't change often):**
    *   Calculate the SHA256 (or SHA384/SHA512) hash of your `assets/index.js` file.
    *   Modify your server/hosting configuration to add this hash to the `script-src` directive in the `Content-Security-Policy` HTTP header. Example: `script-src 'strict-dynamic' 'sha256-HASH_OF_ASSETS_INDEX_JS_HERE' 'unsafe-eval';`
    *   If `assets/index.js` changes, you will need to update this hash in the HTTP header.

**Important Notes on the Original Issue Description:**
*   You mentioned that `index.html` had CDN links for Tailwind and Babel, and that `.tsx` files were being transpiled in the browser.
*   The current codebase does not reflect this:
    *   `index.html` loads a bundled `./assets/index.js`.
    *   There are no CDN links for Tailwind or Babel in `index.html`.
    *   No `.tsx` source files were found in the repository.
*   The application appears to use a build process that bundles React, Tailwind CSS, and other assets into `assets/index.js`. The CSP issue directly blocks this bundle.

If the `'unsafe-eval'` directive (present in both the meta tag and the problematic header) is still flagged as an issue after `assets/index.js` loads, it's likely due to how the bundled code in `assets/index.js` operates. However, the primary problem is getting `assets/index.js` to load first.