### PR TITLE
Fix: Allow unsafe-inline styles in CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TravelStoreHN</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; connect-src 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self';">
   <script type="module" crossorigin src="./assets/index.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-800">


### PR DESCRIPTION
This change modifies the Content Security Policy in index.html to include 'unsafe-inline' for the style-src directive.

This is a workaround to resolve CSP errors caused by JavaScript dynamically applying inline styles in the minified assets/index.js.

The ideal long-term solution is to refactor the original JavaScript source to use CSS classes instead of direct style manipulation.